### PR TITLE
Move Telemetry event generation outside of adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HTTPClient
 
+[![Docs](https://img.shields.io/badge/api-docs-green.svg?style=flat)](https://channexio.github.io/http_client/)
+
 <!-- MDOC !-->
 
 Facade for HTTP client.
@@ -24,40 +26,44 @@ end
 ```
 
 This way, all requests done through the `GitHub` module will be done to the GitHub API:
-    
+
     GitHub.read_repo("/repos/ChannexIO/http_client", headers, options)
     #=> will issue a GET request at https://api.github.com/repos/ChannexIO/http_client
 
 By default requests done through HTTPoison client, to use Finch, for example, 
 add `use` options:
-    
+
     use HTTPClient, adapter: :finch
 
 ## Telemetry
 
 HTTPClient uses Telemetry to provide the following events:
 
-  * `[:http_client, :request, :start]` - Executed before sending a request.
+-   `[:http_client, :request, :start]` - Executed before sending a request.
 
     #### Measurements:
-    * `:system_time` - The system time
+
+    -   `:system_time` - The system time
 
     #### Metadata:
-    * `:method` - The method used in the request.
-    * `:url` - The url address.
-    * `:options` - The request options.
 
-  * `[:http_client, :request, :stop]` - Executed after a request is finished.
+    -   `:adapter` - The name of adapter impelementation.
+    -   `:args` - The arguments passed in the request (url, headers, etc.).
+    -   `:method` - The method used in the request.
+
+-   `[:http_client, :request, :stop]` - Executed after a request is finished.
 
     #### Measurements:
-    * `:duration` - Duration to make the request.
+
+    -   `:duration` - Duration to make the request.
 
     #### Metadata:
-    * `:method` - The method used in the request.
-    * `:url` - The url address.
-    * `:options` - The request options.
-    * `:status_code` - This value is optional. The response status code.
-    * `:error` - This value is optional. It includes any errors that occured while making the request.
+
+    -   `:adapter` - The name of adapter impelementation.
+    -   `:args` - The arguments passed in the request (url, headers, etc.).
+    -   `:method` - The method used in the request.
+    -   `:status_code` - This value is optional. The response status code.
+    -   `:error` - This value is optional. It includes any errors that occured while making the request.
 
 See the `HTTPClient.Telemetry` module for details on specific events.
 

--- a/lib/http_client.ex
+++ b/lib/http_client.ex
@@ -19,7 +19,7 @@ defmodule HTTPClient do
       """
       @spec get(Adapter.url(), Adapter.headers(), Adapter.options()) :: Adapter.response()
       def get(url, headers, options) do
-        @adapter.get(url, headers, options)
+        Adapter.get(@adapter, url, headers, options)
       end
 
       @doc """
@@ -30,7 +30,7 @@ defmodule HTTPClient do
       @spec post(Adapter.url(), Adapter.body(), Adapter.headers(), Adapter.options()) ::
               Adapter.response()
       def post(url, body, headers, options) do
-        @adapter.post(url, body, headers, options)
+        Adapter.post(@adapter, url, body, headers, options)
       end
 
       @doc """
@@ -41,7 +41,7 @@ defmodule HTTPClient do
       @spec put(Adapter.url(), Adapter.body(), Adapter.headers(), Adapter.options()) ::
               Adapter.response()
       def put(url, body, headers, options) do
-        @adapter.put(url, body, headers, options)
+        Adapter.put(@adapter, url, body, headers, options)
       end
 
       @doc """
@@ -52,7 +52,7 @@ defmodule HTTPClient do
       @spec patch(Adapter.url(), Adapter.body(), Adapter.headers(), Adapter.options()) ::
               Adapter.response()
       def patch(url, body, headers, options) do
-        @adapter.patch(url, body, headers, options)
+        Adapter.patch(@adapter, url, body, headers, options)
       end
 
       @doc """
@@ -62,7 +62,7 @@ defmodule HTTPClient do
       """
       @spec delete(Adapter.url(), Adapter.headers(), Adapter.options()) :: Adapter.response()
       def delete(url, headers, options) do
-        @adapter.delete(url, headers, options)
+        Adapter.delete(@adapter, url, headers, options)
       end
 
       @doc """
@@ -88,7 +88,7 @@ defmodule HTTPClient do
               Adapter.options()
             ) :: Adapter.response()
       def request(method, url, body, headers, options) do
-        @adapter.request(method, url, body, headers, options)
+        Adapter.request(@adapter, method, url, body, headers, options)
       end
     end
   end

--- a/lib/http_client/adapters/finch.ex
+++ b/lib/http_client/adapters/finch.ex
@@ -3,7 +3,7 @@ defmodule HTTPClient.Adapters.Finch do
   Implementation of `HTTPClient.Adapter` behaviour using Finch HTTP client.
   """
 
-  alias HTTPClient.{Error, Response, Telemetry}
+  alias HTTPClient.{Error, Response}
 
   @type method() :: Finch.http_method()
   @type url() :: Finch.url()
@@ -47,23 +47,11 @@ defmodule HTTPClient.Adapters.Finch do
     url = build_request_url(url, options[:params])
     headers = add_basic_auth_header(headers, options[:basic_auth])
 
-    metadata = %{
-      method: method,
-      url: url,
-      options: options
-    }
-
-    start_time = Telemetry.start(:request, metadata)
-
     case Finch.request(FinchHTTPClient, method, url, headers, body, options) do
       {:ok, %{status: status, body: body, headers: headers}} ->
-        metadata = Map.put(metadata, :status_code, status)
-        Telemetry.stop(:request, start_time, metadata)
         {:ok, %Response{status: status, body: body, headers: headers}}
 
       {:error, error} ->
-        metadata = Map.put(metadata, :error, error)
-        Telemetry.stop(:request, start_time, metadata)
         {:error, %Error{reason: error.reason}}
     end
   end

--- a/lib/http_client/adapters/httpoison.ex
+++ b/lib/http_client/adapters/httpoison.ex
@@ -3,7 +3,7 @@ defmodule HTTPClient.Adapters.HTTPoison do
   Implementation of `HTTPClient.Adapter` behaviour using HTTPoison HTTP client.
   """
 
-  alias HTTPClient.{Error, Response, Telemetry}
+  alias HTTPClient.{Error, Response}
 
   @type method() :: HTTPoison.Request.method()
   @type url() :: HTTPoison.Request.url()
@@ -46,23 +46,11 @@ defmodule HTTPClient.Adapters.HTTPoison do
   defp perform_request(method, url, headers, body, options) do
     options = add_basic_auth_option(options, options[:basic_auth])
 
-    metadata = %{
-      method: method,
-      url: url,
-      options: options
-    }
-
-    start_time = Telemetry.start(:request, metadata)
-
     case HTTPoison.request(method, url, body, headers, options) do
       {:ok, %{status_code: status, body: body, headers: headers}} ->
-        metadata = Map.put(metadata, :status_code, status)
-        Telemetry.stop(:request, start_time, metadata)
         {:ok, %Response{status: status, body: body, headers: headers}}
 
       {:error, error} ->
-        metadata = Map.put(metadata, :error, error)
-        Telemetry.stop(:request, start_time, metadata)
         {:error, %Error{reason: error.reason}}
     end
   end

--- a/lib/http_client/telemetry.ex
+++ b/lib/http_client/telemetry.ex
@@ -12,9 +12,9 @@ defmodule HTTPClient.Telemetry do
     * `:system_time` - The system time
 
     #### Metadata:
+    * `:adapter` - The name of adapter impelementation.
+    * `:args` - The arguments passed in the request (url, headers, etc.).
     * `:method` - The method used in the request.
-    * `:url` - The url address.
-    * `:options` - The request options.
 
   * `[:http_client, :request, :stop]` - Executed after a request is finished.
 
@@ -22,9 +22,9 @@ defmodule HTTPClient.Telemetry do
     * `:duration` - Duration to make the request.
 
     #### Metadata:
+    * `:adapter` - The name of adapter impelementation.
+    * `:args` - The arguments passed in the request (url, headers, etc.).
     * `:method` - The method used in the request.
-    * `:url` - The url address.
-    * `:options` - The request options.
     * `:status_code` - This value is optional. The response status code.
     * `:error` - This value is optional. It includes any errors that occured while making the request.
   """

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -107,28 +107,28 @@ defmodule HTTPClientTest do
         case event do
           [:http_client, :request, :start] ->
             assert is_integer(measurements.system_time)
-            assert meta.method == :get
+            assert meta.adapter == HTTPClient.Adapters.HTTPoison
 
-            assert meta.options == [
-                     hackney: [basic_auth: {"username", "password"}],
-                     params: %{a: 1, b: 2},
-                     basic_auth: {"username", "password"}
+            assert meta.args == [
+                     endpoint(bypass),
+                     [{"content-type", "application/json"}],
+                     [params: %{a: 1, b: 2}, basic_auth: {"username", "password"}]
                    ]
 
-            assert meta.url == endpoint(bypass)
+            assert meta.method == :get
             send(parent, {ref, :start})
 
           [:http_client, :request, :stop] ->
             assert is_integer(measurements.duration)
-            assert meta.method == :get
+            assert meta.adapter == HTTPClient.Adapters.HTTPoison
 
-            assert meta.options == [
-                     hackney: [basic_auth: {"username", "password"}],
-                     params: %{a: 1, b: 2},
-                     basic_auth: {"username", "password"}
+            assert meta.args == [
+                     endpoint(bypass),
+                     [{"content-type", "application/json"}],
+                     [params: %{a: 1, b: 2}, basic_auth: {"username", "password"}]
                    ]
 
-            assert meta.url == endpoint(bypass)
+            assert meta.method == :get
             assert meta.status_code == 200
             send(parent, {ref, :stop})
 


### PR DESCRIPTION
Problem: using telemetry events generation inside adapter implementation increase boilerplate and may cause errors while implementing new adapter

Solution: wrap callbacks inside behaviour module where telemetry events will be generated for all adapters implementations